### PR TITLE
Updated Gradle instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The most recent release is JNanoId 2.0.0.
 ### Gradle
 
 ```groovy
-compile 'com.aventrix.jnanoid:jnanoid:2.0.0'
+implementation 'com.aventrix.jnanoid:jnanoid:2.0.0'
 ```
 
 ## Usage


### PR DESCRIPTION
Removed deprecated "compile" in favor of "implementation" in the instructions for adding jnanoid to a Gradle project. 

Thanks for the library. Easy to use and a great help with what I'm working on.