### PR TITLE
Add convenience method to generate randomNanoId with just a size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>

--- a/src/main/java/com/aventrix/jnanoid/jnanoid/NanoIdUtils.java
+++ b/src/main/java/com/aventrix/jnanoid/jnanoid/NanoIdUtils.java
@@ -78,6 +78,20 @@ public final class NanoIdUtils {
     }
 
     /**
+     * Static factory to retrieve a url-friendly, pseudo randomly generated, NanoId String.
+     *
+     * The NanoId String is generated using a cryptographically strong pseudo random number
+     * generator.
+     *
+     * @param size     The number of symbols in the NanoId String.
+     *
+     * @return A randomly generated NanoId String.
+     */
+    public static String randomNanoId(int size) {
+        return randomNanoId(DEFAULT_NUMBER_GENERATOR, DEFAULT_ALPHABET, size);
+    }
+
+    /**
      * Static factory to retrieve a NanoId String.
      *
      * The string is generated using the given random number generator.
@@ -125,10 +139,7 @@ public final class NanoIdUtils {
                         return idBuilder.toString();
                     }
                 }
-
             }
-
         }
-
     }
 }

--- a/src/test/java/com/aventrix/jnanoid/NanoIdUtilsTest.java
+++ b/src/test/java/com/aventrix/jnanoid/NanoIdUtilsTest.java
@@ -151,6 +151,19 @@ public class NanoIdUtilsTest {
     }
 
     @Test
+    public void NanoIdUtils_DefinedSizes_Success() {
+
+        //Test ID generation with all sizes between 1 and 1,000.
+        for (int size = 1; size <= 1000; size++) {
+
+            final String id = NanoIdUtils.randomNanoId(size);
+
+            assertEquals(size, id.length());
+        }
+
+    }
+
+    @Test
     public void NanoIdUtils_WellDistributed_Success() {
 
         //Test if symbols in the generated IDs are well distributed.


### PR DESCRIPTION
As mentioned in issue #5 
I'm happy with the default alphabet and the secure random
and I just wanted to ease the usage for the normal user, when NanoIds of different sized are needed